### PR TITLE
fix: validate numeric action inputs with sane bounds

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -3,15 +3,15 @@ description: "Github Action for running Ansible Playbooks with advanced configur
 
 inputs:
     execution_timeout:
-        description: "Timeout in minutes for the playbook execution (default: 30)."
+        description: "Timeout in minutes for the playbook execution (1-1440, default: 30)."
         required: false
         default: "30"
     retries:
-        description: "Number of times to retry on failure (0 = no retries, default: 0)."
+        description: "Number of times to retry on failure (0-100, 0 = no retries, default: 0)."
         required: false
         default: "0"
     retry_delay:
-        description: "Delay in seconds between retries (default: 30)."
+        description: "Delay in seconds between retries (0-3600, default: 30)."
         required: false
         default: "30"
 
@@ -139,7 +139,7 @@ inputs:
         description: "Performs a syntax check on the playbook, without executing it."
         required: false
     forks:
-        description: "Defines the number of parallel processes to use during playbook execution."
+        description: "Defines the number of parallel processes to use during playbook execution (1-1000, default: 5)."
         required: false
 
     # Authentication and Vault

--- a/main.go
+++ b/main.go
@@ -903,6 +903,53 @@ func runAnsibleLint(ctx context.Context, playbooks []string) error {
 }
 
 // run is the main action for executing the playbooks.
+// numericBound describes the accepted range for an integer action input.
+// min/max are inclusive. warnAbove (when > 0) logs a warning for values that
+// are technically valid but almost certainly a misconfiguration.
+type numericBound struct {
+	flag      string
+	min       int
+	max       int
+	warnAbove int
+}
+
+// numericBounds lists the validation rules for every integer input. Timeouts
+// must be at least 1 (a zero execution-timeout would cancel the context
+// immediately); counters and delays must be non-negative.
+// For the optional ansible timeouts a value of 0 means "unset — use ansible's
+// own default", so their minimum is 0. execution-timeout drives the action's
+// own context and must be at least 1 (its default is 30); forks defaults to 5.
+var numericBounds = []numericBound{
+	{flag: "execution-timeout", min: 1, max: 1440, warnAbove: 360}, // minutes (<= 24h)
+	{flag: "forks", min: 1, max: 1000, warnAbove: 100},             // parallelism (default 5)
+	{flag: "timeout", min: 0, max: 3600, warnAbove: 600},           // connection seconds (0 = ansible default)
+	{flag: "galaxy-timeout", min: 0, max: 3600, warnAbove: 600},    // seconds (0 = ansible default)
+	{flag: "fact-caching-timeout", min: 0, max: 31536000},          // seconds (0 = no expiry)
+	{flag: "gather-timeout", min: 0, max: 3600, warnAbove: 600},    // seconds (0 = ansible default)
+	{flag: "poll-interval", min: 0, max: 3600},                     // seconds (0 = ansible default)
+	{flag: "retries", min: 0, max: 100, warnAbove: 20},             // attempts (0 = no retries)
+	{flag: "retry-delay", min: 0, max: 3600, warnAbove: 600},       // seconds
+	{flag: "verbose", min: 0, max: 4},                              // -v .. -vvvv
+	{flag: "max-fail-percentage", min: 0, max: 100},                // percent
+}
+
+// validateNumericInputs enforces numericBounds for every integer flag that was
+// set, returning an error for out-of-range values and logging a warning for
+// suspiciously large but valid ones. Flags left at their default are skipped so
+// a default of 0 (e.g. retries) does not trip a min of 1 it does not have.
+func validateNumericInputs(c *cli.Command) error {
+	for _, b := range numericBounds {
+		v := c.Int(b.flag)
+		if v < b.min || v > b.max {
+			return fmt.Errorf("invalid value for --%s: %d (must be between %d and %d)", b.flag, v, b.min, b.max)
+		}
+		if b.warnAbove > 0 && v > b.warnAbove {
+			log.Printf("WARNING: --%s is set to %d, which is unusually high (> %d) — double-check this is intended", b.flag, v, b.warnAbove)
+		}
+	}
+	return nil
+}
+
 func run(ctx context.Context, c *cli.Command) (execErr error) {
 	defer func() { writeActionOutputs(execErr) }()
 
@@ -923,6 +970,11 @@ func run(ctx context.Context, c *cli.Command) (execErr error) {
 		return err
 	}
 
+	// Validate numeric inputs (bounds, non-negative, sane maxima).
+	if err := validateNumericInputs(c); err != nil {
+		return err
+	}
+
 	// Run ansible-lint if requested.
 	if c.Bool("lint") {
 		if err := runAnsibleLint(ctx, playbooks); err != nil {
@@ -930,9 +982,10 @@ func run(ctx context.Context, c *cli.Command) (execErr error) {
 		}
 	}
 
-	// Set execution timeout based on flag.
+	// Set execution timeout based on flag. validateNumericInputs guarantees a
+	// minimum of 1 minute, so the context can never be created already-expired.
 	timeoutDuration := time.Duration(c.Int("execution-timeout")) * time.Minute
-	log.Printf("Setting execution timeout to %v minutes", c.Int("execution-timeout"))
+	log.Printf("Setting execution timeout to %d minute(s)", c.Int("execution-timeout"))
 
 	// Create context with timeout.
 	ctx, cancel := context.WithTimeout(ctx, timeoutDuration)

--- a/main.go
+++ b/main.go
@@ -920,23 +920,25 @@ type numericBound struct {
 // own default", so their minimum is 0. execution-timeout drives the action's
 // own context and must be at least 1 (its default is 30); forks defaults to 5.
 var numericBounds = []numericBound{
-	{flag: "execution-timeout", min: 1, max: 1440, warnAbove: 360}, // minutes (<= 24h)
-	{flag: "forks", min: 1, max: 1000, warnAbove: 100},             // parallelism (default 5)
-	{flag: "timeout", min: 0, max: 3600, warnAbove: 600},           // connection seconds (0 = ansible default)
-	{flag: "galaxy-timeout", min: 0, max: 3600, warnAbove: 600},    // seconds (0 = ansible default)
-	{flag: "fact-caching-timeout", min: 0, max: 31536000},          // seconds (0 = no expiry)
-	{flag: "gather-timeout", min: 0, max: 3600, warnAbove: 600},    // seconds (0 = ansible default)
-	{flag: "poll-interval", min: 0, max: 3600},                     // seconds (0 = ansible default)
-	{flag: "retries", min: 0, max: 100, warnAbove: 20},             // attempts (0 = no retries)
-	{flag: "retry-delay", min: 0, max: 3600, warnAbove: 600},       // seconds
-	{flag: "verbose", min: 0, max: 4},                              // -v .. -vvvv
-	{flag: "max-fail-percentage", min: 0, max: 100},                // percent
+	{flag: "execution-timeout", min: 1, max: 1440, warnAbove: 360},    // minutes (<= 24h)
+	{flag: "forks", min: 1, max: 1000, warnAbove: 100},                // parallelism (default 5)
+	{flag: "timeout", min: 0, max: 3600, warnAbove: 600},              // connection seconds (0 = ansible default)
+	{flag: "galaxy-timeout", min: 0, max: 3600, warnAbove: 600},       // seconds (0 = ansible default)
+	{flag: "fact-caching-timeout", min: 0, max: 31536000},             // seconds (0 = no expiry)
+	{flag: "gather-timeout", min: 0, max: 3600, warnAbove: 600},       // seconds (0 = ansible default)
+	{flag: "poll-interval", min: 0, max: 3600},                        // seconds (0 = ansible default)
+	{flag: "retries", min: 0, max: 100, warnAbove: 20},                // attempts (0 = no retries)
+	{flag: "retry-delay", min: 0, max: 3600, warnAbove: 600},          // seconds
+	{flag: "verbose", min: 0, max: 4},                                 // -v .. -vvvv
+	{flag: "max-fail-percentage", min: 0, max: 100},                   // percent
+	{flag: "galaxy-required-valid-signature-count", min: 0, max: 100}, // GPG signatures (0 = unset)
 }
 
-// validateNumericInputs enforces numericBounds for every integer flag that was
-// set, returning an error for out-of-range values and logging a warning for
-// suspiciously large but valid ones. Flags left at their default are skipped so
-// a default of 0 (e.g. retries) does not trip a min of 1 it does not have.
+// validateNumericInputs enforces numericBounds for every integer flag in the
+// table, returning an error for out-of-range values and logging a warning for
+// suspiciously large but valid ones. Every entry is checked unconditionally;
+// each flag's default sits within its own bound (e.g. retries defaults to 0 and
+// has min 0), so unset flags pass without a special skip.
 func validateNumericInputs(c *cli.Command) error {
 	for _, b := range numericBounds {
 		v := c.Int(b.flag)

--- a/main_test.go
+++ b/main_test.go
@@ -986,3 +986,39 @@ func TestValidateAgentPID(t *testing.T) {
 		})
 	}
 }
+
+func TestValidateNumericInputs(t *testing.T) {
+	tmpDir := t.TempDir()
+	pbFlag := createTempFile(t, tmpDir, "pb.yml", "---\n- hosts: all\n")
+	invFlag := createTempFile(t, tmpDir, "inv.yml", "all:\n  hosts:\n    localhost:\n")
+	tests := []struct {
+		name    string
+		args    []string
+		wantErr bool
+	}{
+		{"defaults are valid", []string{"test", "--playbook", pbFlag, "--inventory", invFlag}, false},
+		{"execution-timeout zero rejected", []string{"test", "--playbook", pbFlag, "--inventory", invFlag, "--execution-timeout", "0"}, true},
+		{"execution-timeout negative rejected", []string{"test", "--playbook", pbFlag, "--inventory", invFlag, "--execution-timeout", "-5"}, true},
+		{"execution-timeout too high rejected", []string{"test", "--playbook", pbFlag, "--inventory", invFlag, "--execution-timeout", "5000"}, true},
+		{"execution-timeout valid", []string{"test", "--playbook", pbFlag, "--inventory", invFlag, "--execution-timeout", "60"}, false},
+		{"retry-delay negative rejected", []string{"test", "--playbook", pbFlag, "--inventory", invFlag, "--retry-delay", "-1"}, true},
+		{"retry-delay zero allowed", []string{"test", "--playbook", pbFlag, "--inventory", invFlag, "--retry-delay", "0"}, false},
+		{"retries negative rejected", []string{"test", "--playbook", pbFlag, "--inventory", invFlag, "--retries", "-1"}, true},
+		{"forks zero rejected", []string{"test", "--playbook", pbFlag, "--inventory", invFlag, "--forks", "0"}, true},
+		{"forks valid", []string{"test", "--playbook", pbFlag, "--inventory", invFlag, "--forks", "10"}, false},
+		{"optional timeout zero allowed", []string{"test", "--playbook", pbFlag, "--inventory", invFlag, "--timeout", "0"}, false},
+		{"verbose out of range rejected", []string{"test", "--playbook", pbFlag, "--inventory", invFlag, "--verbose", "9"}, true},
+		{"max-fail-percentage over 100 rejected", []string{"test", "--playbook", pbFlag, "--inventory", invFlag, "--max-fail-percentage", "150"}, true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cmd := newTestCommand(func(ctx context.Context, c *cli.Command) error {
+				return validateNumericInputs(c)
+			})
+			err := cmd.Run(context.Background(), tt.args)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("args %v: error = %v, wantErr %v", tt.args, err, tt.wantErr)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

Two P1 bugs around numeric inputs:

- `execution_timeout=0` built an already-expired context → the run was cancelled immediately.
- `retry_delay`, `retries`, `forks` and the various timeouts accepted negative or absurd values unchecked.

Fix: a `validateNumericInputs(c)` step early in `run()` enforces a `numericBounds` table (min/max per flag) and logs a warning for valid-but-suspicious values.

- `execution-timeout` and `forks` require ≥ 1 (defaults 30 / 5).
- The optional ansible timeouts (`timeout`, `galaxy-timeout`, `gather-timeout`, `poll-interval`, `fact-caching-timeout`) keep min 0 — 0 means "use ansible's own default", so a default of 0 isn't rejected.
- `retries`/`retry-delay` non-negative; `verbose` 0–4; `max-fail-percentage` 0–100.
- Ranges documented in `action.yml` for `execution_timeout`, `retries`, `retry_delay`, `forks`.

Table-driven tests cover zero/negative/over-max/valid cases.

## Test plan

- [x] `gofmt`, `go build`, `go vet`, `go test ./...` (67 tests) pass
- [x] action.yml valid YAML
- [x] new `TestValidateNumericInputs`