### PR TITLE
chore(repo): add lefthook, REVIEW.md and .dockerignore

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,38 @@
+# The Dockerfile does `COPY . .`, so keep the build context lean — exclude
+# VCS, CI, docs and local tooling that the Go build does not need.
+
+# VCS and CI
+.git/
+.github/
+.gitignore
+.gitattributes
+
+# Docs and meta
+*.md
+LICENSE
+AGENTS.md
+CLAUDE.md
+REVIEW.md
+CONTRIBUTING.md
+
+# Lint / tooling configs
+.editorconfig
+.yamllint.yml
+.markdownlint.json
+.gitleaks.toml
+.secretlintrc.json
+.trivy.yaml
+.golangci.yml
+lefthook.yml
+
+# Tests and local artifacts
+tests/
+test-results/
+coverage.out
+coverage.html
+*.test
+
+# Editor / OS
+.idea/
+.vscode/
+.DS_Store

--- a/REVIEW.md
+++ b/REVIEW.md
@@ -1,0 +1,39 @@
+# Code Review Guidelines
+
+## Scope
+
+In scope:
+
+- Go source changes (`main.go`, `*.go`)
+- `action.yml` input/output contract changes
+- `Dockerfile` changes (build, base image, multi-arch)
+- CI/CD workflow changes
+- Renovate configuration updates
+
+Out of scope:
+
+- Renovate dependency-only PRs (patch/minor with automerge enabled)
+- Generated changelog entries from release automation
+
+## Required checks
+
+- No secrets committed — no credentials, tokens, or keys in source or workflows
+- `gofmt` clean and `golangci-lint` passes
+- `go test ./...` passes (with `-race`)
+- Action integration tests pass (the `test-*` jobs in pull-request.yml)
+- Security scans pass (gitleaks, trivy, CodeQL)
+- Backwards-compatible `action.yml` inputs — no breaking changes to existing input names without a major bump
+- Numeric inputs are bounds-validated; secrets (SSH keys, passphrases) never interpolated into shell
+
+## Severity levels
+
+| Level        | Meaning                                             | Merge impact       |
+| ------------ | --------------------------------------------------- | ------------------ |
+| Bug          | Incorrect behavior or broken contract               | Blocks merge       |
+| Nit          | Minor issue — suboptimal but not incorrect          | Non-blocking       |
+| Pre-existing | Issue present before this PR; flagged for awareness | No action required |
+
+## Skip
+
+- Renovate PRs with `automerge: true` (patch/minor) after CI passes
+- Documentation-only changes with no functional impact

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -5,20 +5,21 @@
 # (>= v8.19 for the `git --staged` subcommand), actionlint.
 #
 # Stack: Go GitHub Action. Adapted from arillso/ansible.system, with
-# ansible-lint swapped for gofmt + golangci-lint.
+# ansible-lint swapped for gofmt + golangci-lint. No prettier: yamllint and
+# markdownlint already cover yml/md, and the repo's 4-space YAML/.editorconfig
+# conventions diverge from Prettier's defaults.
 
 pre-commit:
     parallel: true
     commands:
         gofmt:
             glob: "*.go"
-            run: gofmt -l {staged_files}
+            # gofmt -l only prints unformatted files and still exits 0, so the
+            # commit must be blocked explicitly when the list is non-empty.
+            run: test -z "$(gofmt -l {staged_files})"
         golangci-lint:
             glob: "*.go"
             run: golangci-lint run
-        prettier:
-            glob: "*.{json,yml,yaml,md}"
-            run: npx --yes -- prettier --check {staged_files}
         yamllint:
             glob: "*.{yml,yaml}"
             run: yamllint -c .yamllint.yml {staged_files}
@@ -37,4 +38,4 @@ pre-push:
         gitleaks-full:
             run: gitleaks git --redact --no-banner
         go-test:
-            run: go test ./...
+            run: go test -race ./...

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -1,0 +1,40 @@
+---
+# Lefthook git hooks — run `lefthook install` once after cloning.
+# Tools without a system binary are installed on-demand via `npx --yes`.
+# System binaries: gofmt (from Go), golangci-lint, yamllint, gitleaks
+# (>= v8.19 for the `git --staged` subcommand), actionlint.
+#
+# Stack: Go GitHub Action. Adapted from arillso/ansible.system, with
+# ansible-lint swapped for gofmt + golangci-lint.
+
+pre-commit:
+    parallel: true
+    commands:
+        gofmt:
+            glob: "*.go"
+            run: gofmt -l {staged_files}
+        golangci-lint:
+            glob: "*.go"
+            run: golangci-lint run
+        prettier:
+            glob: "*.{json,yml,yaml,md}"
+            run: npx --yes -- prettier --check {staged_files}
+        yamllint:
+            glob: "*.{yml,yaml}"
+            run: yamllint -c .yamllint.yml {staged_files}
+        markdownlint:
+            glob: "*.md"
+            run: npx --yes -- markdownlint-cli2 {staged_files}
+        actionlint:
+            glob: ".github/workflows/*.{yml,yaml}"
+            run: actionlint {staged_files}
+        gitleaks:
+            run: gitleaks git --staged --redact --no-banner
+
+pre-push:
+    parallel: true
+    commands:
+        gitleaks-full:
+            run: gitleaks git --redact --no-banner
+        go-test:
+            run: go test ./...


### PR DESCRIPTION
## Summary

Repo-standard file drift for action.playbook (Go + Docker action):

- **lefthook.yml** — pre-commit (gofmt, golangci-lint, prettier, yamllint, markdownlint, actionlint, gitleaks), pre-push (gitleaks-full, `go test`). Adapted from arillso/ansible.system with the Go toolchain instead of ansible-lint.
- **REVIEW.md** — Go-Action-scoped review guidelines (read by ai-claude-review).
- **.dockerignore** — the Dockerfile does `COPY . .`, so trim the context to what the Go build needs.

Workflows were already migrated to the event-focused layout in #179. gh-API settings + the missing branch ruleset are handled separately (API, no commit).

## Test plan

- [ ] CI green