### PR TITLE
docs(agents): document the arillso/ansible base image coupling

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -32,6 +32,24 @@ This is a Docker-based GitHub Action written in Go that executes Ansible playboo
 - All Ansible options are exposed as action inputs
 - Docker image is published to ghcr.io/arillso/action.playbook
 
+## Base image coupling (arillso/ansible)
+
+The production stage builds `FROM arillso/ansible:<ansible-core-version>@sha256:<digest>`
+(produced by the `arillso/docker.ansible` repo).
+
+- **Tag = the ansible-core version** the image ships (e.g. `2.21.1`), not a
+  docker.ansible-specific semver. docker.ansible publishes image tags `latest`,
+  `<ansible-core-version>` and `<version>-<sha>`; its git releases are
+  date-tagged (rolling release), but the image version tag tracks ansible-core.
+- **Pin tag + digest.** The tag documents which Ansible the action runs; the
+  `@sha256` digest makes the build reproducible.
+- **Renovate keeps it current.** The `dockerfile` manager (via the
+  `renovate-actions` preset, group `docker-images`) bumps both the tag and the
+  digest when a newer `arillso/ansible` version ships — no manual cadence to
+  track. Verified with `renovate --dry-run`: it offers the tag+digest update.
+- **On an ansible-core major/minor bump,** review the action's behaviour
+  against the new Ansible before merging the Renovate PR (flag/output changes).
+
 ## Do Not
 
 - Add unnecessary dependencies


### PR DESCRIPTION
## Summary

Closes the Notion ticket "Kopplung action.playbook → docker.ansible-Image dokumentieren". Documents in AGENTS.md the base-image version/update strategy that was previously undocumented.

While investigating, two sibling tickets turned out to be **already satisfied** (handled separately in Notion, not in this PR):
- *Base-Image-Update-Prozess / Renovate-Tracking* — Renovate already tracks `arillso/ansible` (the `dockerfile` manager via the `renovate-actions` preset). `renovate --dry-run` offers the `2.20.5 → 2.21.1` + digest update; it just hadn't fired yet (the open #175 docker-images PR is from 2026-06-16, before 2.21.1 shipped).
- *Go-Build-Layer-Caching* — the Dockerfile already copies `go.mod`/`go.sum` and runs `go mod download` in their own layer before `COPY . .`.

## Test plan

- [ ] CI green (docs only)