### PR TITLE
fix(docker): bump base image to arillso/ansible 2.21.1 (Alpine 3.24)

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -6,7 +6,7 @@
             "description": "Alpine packages (repology)",
             "matchManagers": ["custom.regex"],
             "matchDatasources": ["repology"],
-            "matchPackageNames": ["/^alpine_3_21\\//"],
+            "matchPackageNames": ["/^alpine_3_24\\//"],
             "groupName": "Alpine packages"
         }
     ],
@@ -19,7 +19,7 @@
             ],
             "versioningTemplate": "loose",
             "datasourceTemplate": "repology",
-            "packageNameTemplate": "alpine_3_21/{{depName}}"
+            "packageNameTemplate": "alpine_3_24/{{depName}}"
         }
     ]
 }

--- a/Dockerfile
+++ b/Dockerfile
@@ -28,7 +28,7 @@ RUN go build -ldflags="-s -w" -o main .
 # -------------------------
 # Stage 2: Production Stage (Alpine Linux)
 # -------------------------
-FROM arillso/ansible:2.20.5@sha256:17a5d6fcff85c3be14f0ba17d2d0d4a3ef706c66fc774f326a61b3d935014919
+FROM arillso/ansible:2.21.1@sha256:def13065d6d7e361a2e7d0d823feb4e09c1425561310c2a2bc08faeef3a1fb86
 # Use an Ansible-based Alpine Linux image as the base for the production stage.
 
 # Switch to root user to execute system-level modifications.
@@ -37,7 +37,7 @@ USER root
 # Update package repositories and install the 'shadow' package for access to usermod and groupmod commands.
 RUN apk update && \
 	apk add --no-cache \
-	shadow=4.18.0-r0
+	shadow=4.18.0-r1
 
 # Modify the UID and GID of the 'ansible' user from 1000 to 1001 and update file ownership:
 # - Change the UID of user 'ansible' to 1001.


### PR DESCRIPTION
## Summary

Renovate's base-image bump `arillso/ansible 2.20.5 → 2.21.1` (#184) failed on its own: 2.21.1 moves the base from Alpine 3.21 to 3.24, where `shadow` is `4.18.0-r1` (`-r0` is gone), so the pinned `shadow=4.18.0-r0` broke `apk add`. This PR does the bump **together** with the matching pin so the build stays green.

- `FROM arillso/ansible:2.21.1@sha256:def1…` (tag tracks ansible-core, see AGENTS.md base-image-coupling)
- `shadow 4.18.0-r0 → 4.18.0-r1` (Alpine 3.24)
- `renovate.json` apk customManager: `alpine_3_21 → alpine_3_24` — it tracked a stale Alpine minor, so the shadow pin never bumped in step with the base image (the A/B drift). Now points at the current base Alpine.

Supersedes the Renovate-only #184 (closed), which couldn't carry the shadow fix.

## Test plan

- [x] Image builds against arillso/ansible:2.21.1
- [ ] CI green