### PR TITLE
fix(docker): build binary for the target architecture

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,14 +1,19 @@
 # -------------------------
 # Stage 1: Build Stage
 # -------------------------
-FROM golang:1.26-alpine@sha256:0178a641fbb4858c5f1b48e34bdaabe0350a330a1b1149aabd498d0699ff5fb2 AS builder
+FROM --platform=$BUILDPLATFORM golang:1.26-alpine@sha256:0178a641fbb4858c5f1b48e34bdaabe0350a330a1b1149aabd498d0699ff5fb2 AS builder
 # Use the official Golang Alpine image and assign this build stage the name "builder".
+# The builder runs natively on the build platform and cross-compiles for the target.
+
+# Target platform arguments injected by Docker Buildx for multi-platform builds.
+ARG TARGETOS
+ARG TARGETARCH
 
 # Set build environment variables for module support and cross-compilation.
 ENV GO111MODULE=on \
 	CGO_ENABLED=0 \
-	GOOS=linux \
-	GOARCH=amd64
+	GOOS=${TARGETOS} \
+	GOARCH=${TARGETARCH}
 
 # Set the working directory inside the container where the build will be executed.
 WORKDIR /app

--- a/Makefile
+++ b/Makefile
@@ -43,7 +43,7 @@ action-test: build-docker ## Run action tests with test playbook
 
 ## Building
 build: ## Build Go binary
-	CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -ldflags="-s -w" -o main .
+	CGO_ENABLED=0 GOOS=linux go build -ldflags="-s -w" -o main .
 
 build-docker: ## Build Docker image
 	docker build -t action-playbook:local .


### PR DESCRIPTION
## Summary

- The builder stage hardcoded `GOARCH=amd64`, so the `linux/arm64` manifest shipped an x86-64 binary that cannot run natively on ARM64. The stage now runs on `$BUILDPLATFORM` and derives `GOOS`/`GOARCH` from the `TARGETOS`/`TARGETARCH` args Buildx injects, which also removes QEMU emulation from the Go compile step.
- `make build` no longer pins `GOARCH=amd64`, so the local target follows the host architecture. `GOOS=linux` stays, since the target builds a binary for the container image.
- Both `sha256:` digest pins, the build output path and the `COPY --from=builder` line are unchanged.

## Test plan

- [ ] `go test ./...` passes (verified locally with Go 1.26.5).
- [ ] CI green — note that `pull-request.yml` builds without a `platforms:` argument, so it only covers the runner architecture (amd64). It proves the `ARG` declarations are valid and the amd64 path still works; the arm64 path is first exercised by the tag build (`tag.yml` uses `platforms: linux/amd64,linux/arm64`).
- [ ] Optional manual check: `docker buildx build --platform linux/arm64 --load .`, then `file` on `/usr/local/bin/main` should report `ELF 64-bit LSB executable, ARM aarch64`.