### PR TITLE
refactor(ci): extract test job preamble into a composite action

### DIFF
--- a/.github/actions/setup-test-image/action.yml
+++ b/.github/actions/setup-test-image/action.yml
@@ -1,13 +1,10 @@
 ---
 name: Setup Test Image
-description: Checks out the repository, prepares Buildx, builds the test image from cache and points action.yml at it.
+description: Prepares Buildx, builds the test image from cache and points action.yml at it. Requires the repository to be checked out first.
 
 runs:
     using: composite
     steps:
-        - name: Checkout code
-          uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
-
         - name: Set up Docker Buildx
           uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4
 

--- a/.github/actions/setup-test-image/action.yml
+++ b/.github/actions/setup-test-image/action.yml
@@ -1,0 +1,26 @@
+---
+name: Setup Test Image
+description: Checks out the repository, prepares Buildx, builds the test image from cache and points action.yml at it.
+
+runs:
+    using: composite
+    steps:
+        - name: Checkout code
+          uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+
+        - name: Set up Docker Buildx
+          uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4
+
+        - name: Pre-build with cache
+          uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7
+          with:
+              context: .
+              load: true
+              tags: action-playbook:test
+              cache-from: type=gha
+              cache-to: type=gha,mode=max
+
+        - name: Update action.yml for testing
+          shell: bash
+          run: |
+              sed -i 's|image: ".*"|image: "docker://action-playbook:test"|' action.yml

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -130,6 +130,9 @@ jobs:
         runs-on: ubuntu-latest
         timeout-minutes: 15
         steps:
+            - name: Checkout code
+              uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+
             - name: Setup test image
               uses: ./.github/actions/setup-test-image
 
@@ -150,6 +153,9 @@ jobs:
         runs-on: ubuntu-latest
         timeout-minutes: 15
         steps:
+            - name: Checkout code
+              uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+
             - name: Setup test image
               uses: ./.github/actions/setup-test-image
 
@@ -174,6 +180,9 @@ jobs:
                 mode: [check, diff, syntax_check, verbose]
             fail-fast: false
         steps:
+            - name: Checkout code
+              uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+
             - name: Setup test image
               uses: ./.github/actions/setup-test-image
 
@@ -197,6 +206,9 @@ jobs:
         runs-on: ubuntu-latest
         timeout-minutes: 20
         steps:
+            - name: Checkout code
+              uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+
             - name: Setup test image
               uses: ./.github/actions/setup-test-image
 
@@ -250,6 +262,9 @@ jobs:
         runs-on: ubuntu-latest
         timeout-minutes: 15
         steps:
+            - name: Checkout code
+              uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+
             - name: Setup test image
               uses: ./.github/actions/setup-test-image
 
@@ -338,6 +353,9 @@ jobs:
         runs-on: ubuntu-latest
         timeout-minutes: 15
         steps:
+            - name: Checkout code
+              uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+
             - name: Setup test image
               uses: ./.github/actions/setup-test-image
 
@@ -379,6 +397,9 @@ jobs:
                 mode: [list_hosts, list_tags, list_tasks]
             fail-fast: false
         steps:
+            - name: Checkout code
+              uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+
             - name: Setup test image
               uses: ./.github/actions/setup-test-image
 
@@ -400,6 +421,9 @@ jobs:
         runs-on: ubuntu-latest
         timeout-minutes: 20
         steps:
+            - name: Checkout code
+              uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+
             - name: Setup test image
               uses: ./.github/actions/setup-test-image
 
@@ -465,6 +489,9 @@ jobs:
         runs-on: ubuntu-latest
         timeout-minutes: 20
         steps:
+            - name: Checkout code
+              uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+
             - name: Setup test image
               uses: ./.github/actions/setup-test-image
 
@@ -526,6 +553,9 @@ jobs:
         runs-on: ubuntu-latest
         timeout-minutes: 15
         steps:
+            - name: Checkout code
+              uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+
             - name: Setup test image
               uses: ./.github/actions/setup-test-image
 
@@ -553,6 +583,9 @@ jobs:
         runs-on: ubuntu-latest
         timeout-minutes: 15
         steps:
+            - name: Checkout code
+              uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+
             - name: Setup test image
               uses: ./.github/actions/setup-test-image
 
@@ -636,6 +669,9 @@ jobs:
         runs-on: ubuntu-latest
         timeout-minutes: 15
         steps:
+            - name: Checkout code
+              uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+
             - name: Setup test image
               uses: ./.github/actions/setup-test-image
 
@@ -670,6 +706,9 @@ jobs:
         runs-on: ubuntu-latest
         timeout-minutes: 15
         steps:
+            - name: Checkout code
+              uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+
             - name: Setup test image
               uses: ./.github/actions/setup-test-image
 
@@ -711,6 +750,9 @@ jobs:
         runs-on: ubuntu-latest
         timeout-minutes: 15
         steps:
+            - name: Checkout code
+              uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+
             - name: Setup test image
               uses: ./.github/actions/setup-test-image
 
@@ -733,6 +775,9 @@ jobs:
         runs-on: ubuntu-latest
         timeout-minutes: 20
         steps:
+            - name: Checkout code
+              uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+
             - name: Setup test image
               uses: ./.github/actions/setup-test-image
 
@@ -797,6 +842,9 @@ jobs:
         runs-on: ubuntu-latest
         timeout-minutes: 15
         steps:
+            - name: Checkout code
+              uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+
             - name: Setup test image
               uses: ./.github/actions/setup-test-image
 

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -845,6 +845,7 @@ jobs:
         name: Test Summary
         needs:
             - setup-environment
+            - build-action
             - test-basic
             - test-advanced
             - test-modes
@@ -909,57 +910,7 @@ jobs:
                   mode: upsert
 
             - name: Test quality gate
+              if: contains(needs.*.result, 'failure')
               run: |
-                  failed_jobs=()
-                  if [[ "${{ needs.test-basic.result }}" == "failure" ]]; then
-                      failed_jobs+=("Basic Tests")
-                  fi
-                  if [[ "${{ needs.test-advanced.result }}" == "failure" ]]; then
-                      failed_jobs+=("Advanced Tests")
-                  fi
-                  if [[ "${{ needs.test-modes.result }}" == "failure" ]]; then
-                      failed_jobs+=("Mode Tests")
-                  fi
-                  if [[ "${{ needs.test-parameters.result }}" == "failure" ]]; then
-                      failed_jobs+=("Parameter Tests")
-                  fi
-                  if [[ "${{ needs.test-ssh-key-handling.result }}" == "failure" ]]; then
-                      failed_jobs+=("SSH Key Handling Tests")
-                  fi
-                  if [[ "${{ needs.test-listing.result }}" == "failure" ]]; then
-                      failed_jobs+=("Listing Mode Tests")
-                  fi
-                  if [[ "${{ needs.test-execution-options.result }}" == "failure" ]]; then
-                      failed_jobs+=("Execution Options Tests")
-                  fi
-                  if [[ "${{ needs.test-multi-input.result }}" == "failure" ]]; then
-                      failed_jobs+=("Multi-Input Tests")
-                  fi
-                  if [[ "${{ needs.test-vault.result }}" == "failure" ]]; then
-                      failed_jobs+=("Vault Tests")
-                  fi
-                  if [[ "${{ needs.test-output.result }}" == "failure" ]]; then
-                      failed_jobs+=("Output Tests")
-                  fi
-                  if [[ "${{ needs.test-lint.result }}" == "failure" ]]; then
-                      failed_jobs+=("Lint Tests")
-                  fi
-                  if [[ "${{ needs.test-retries.result }}" == "failure" ]]; then
-                      failed_jobs+=("Retry Tests")
-                  fi
-                  if [[ "${{ needs.test-privilege-escalation.result }}" == "failure" ]]; then
-                      failed_jobs+=("Privilege Escalation Tests")
-                  fi
-                  if [[ "${{ needs.test-galaxy-options.result }}" == "failure" ]]; then
-                      failed_jobs+=("Galaxy Options Tests")
-                  fi
-                  if [[ "${{ needs.test-connection.result }}" == "failure" ]]; then
-                      failed_jobs+=("Connection Tests")
-                  fi
-
-                  if [[ ${#failed_jobs[@]} -gt 0 ]]; then
-                      echo "Critical tests failed: ${failed_jobs[*]}"
-                      exit 1
-                  fi
-
-                  echo "All critical tests passed"
+                  echo "One or more required jobs failed; see the summary above."
+                  exit 1

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -130,24 +130,8 @@ jobs:
         runs-on: ubuntu-latest
         timeout-minutes: 15
         steps:
-            - name: Checkout code
-              uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
-
-            - name: Set up Docker Buildx
-              uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4
-
-            - name: Pre-build with cache
-              uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7
-              with:
-                  context: .
-                  load: true
-                  tags: action-playbook:test
-                  cache-from: type=gha
-                  cache-to: type=gha,mode=max
-
-            - name: Update action.yml for testing
-              run: |
-                  sed -i 's|image: ".*"|image: "docker://action-playbook:test"|' action.yml
+            - name: Setup test image
+              uses: ./.github/actions/setup-test-image
 
             - name: Run basic playbook
               uses: ./
@@ -166,24 +150,8 @@ jobs:
         runs-on: ubuntu-latest
         timeout-minutes: 15
         steps:
-            - name: Checkout code
-              uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
-
-            - name: Set up Docker Buildx
-              uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4
-
-            - name: Pre-build with cache
-              uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7
-              with:
-                  context: .
-                  load: true
-                  tags: action-playbook:test
-                  cache-from: type=gha
-                  cache-to: type=gha,mode=max
-
-            - name: Update action.yml for testing
-              run: |
-                  sed -i 's|image: ".*"|image: "docker://action-playbook:test"|' action.yml
+            - name: Setup test image
+              uses: ./.github/actions/setup-test-image
 
             - name: Run advanced playbook
               uses: ./
@@ -206,24 +174,8 @@ jobs:
                 mode: [check, diff, syntax_check, verbose]
             fail-fast: false
         steps:
-            - name: Checkout code
-              uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
-
-            - name: Set up Docker Buildx
-              uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4
-
-            - name: Pre-build with cache
-              uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7
-              with:
-                  context: .
-                  load: true
-                  tags: action-playbook:test
-                  cache-from: type=gha
-                  cache-to: type=gha,mode=max
-
-            - name: Update action.yml for testing
-              run: |
-                  sed -i 's|image: ".*"|image: "docker://action-playbook:test"|' action.yml
+            - name: Setup test image
+              uses: ./.github/actions/setup-test-image
 
             - name: Run with ${{ matrix.mode }} mode
               uses: ./
@@ -245,24 +197,8 @@ jobs:
         runs-on: ubuntu-latest
         timeout-minutes: 20
         steps:
-            - name: Checkout code
-              uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
-
-            - name: Set up Docker Buildx
-              uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4
-
-            - name: Pre-build with cache
-              uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7
-              with:
-                  context: .
-                  load: true
-                  tags: action-playbook:test
-                  cache-from: type=gha
-                  cache-to: type=gha,mode=max
-
-            - name: Update action.yml for testing
-              run: |
-                  sed -i 's|image: ".*"|image: "docker://action-playbook:test"|' action.yml
+            - name: Setup test image
+              uses: ./.github/actions/setup-test-image
 
             - name: Test with tags
               uses: ./
@@ -314,24 +250,8 @@ jobs:
         runs-on: ubuntu-latest
         timeout-minutes: 15
         steps:
-            - name: Checkout code
-              uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
-
-            - name: Set up Docker Buildx
-              uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4
-
-            - name: Pre-build with cache
-              uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7
-              with:
-                  context: .
-                  load: true
-                  tags: action-playbook:test
-                  cache-from: type=gha
-                  cache-to: type=gha,mode=max
-
-            - name: Update action.yml for testing
-              run: |
-                  sed -i 's|image: ".*"|image: "docker://action-playbook:test"|' action.yml
+            - name: Setup test image
+              uses: ./.github/actions/setup-test-image
 
             - name: Generate test SSH key (Unix LF format)
               run: |
@@ -418,24 +338,8 @@ jobs:
         runs-on: ubuntu-latest
         timeout-minutes: 15
         steps:
-            - name: Checkout code
-              uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
-
-            - name: Set up Docker Buildx
-              uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4
-
-            - name: Pre-build with cache
-              uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7
-              with:
-                  context: .
-                  load: true
-                  tags: action-playbook:test
-                  cache-from: type=gha
-                  cache-to: type=gha,mode=max
-
-            - name: Update action.yml for testing
-              run: |
-                  sed -i 's|image: ".*"|image: "docker://action-playbook:test"|' action.yml
+            - name: Setup test image
+              uses: ./.github/actions/setup-test-image
 
             - name: Test with non-existent playbook
               uses: ./
@@ -475,24 +379,8 @@ jobs:
                 mode: [list_hosts, list_tags, list_tasks]
             fail-fast: false
         steps:
-            - name: Checkout code
-              uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
-
-            - name: Set up Docker Buildx
-              uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4
-
-            - name: Pre-build with cache
-              uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7
-              with:
-                  context: .
-                  load: true
-                  tags: action-playbook:test
-                  cache-from: type=gha
-                  cache-to: type=gha,mode=max
-
-            - name: Update action.yml for testing
-              run: |
-                  sed -i 's|image: ".*"|image: "docker://action-playbook:test"|' action.yml
+            - name: Setup test image
+              uses: ./.github/actions/setup-test-image
 
             - name: Run with ${{ matrix.mode }}
               uses: ./
@@ -512,24 +400,8 @@ jobs:
         runs-on: ubuntu-latest
         timeout-minutes: 20
         steps:
-            - name: Checkout code
-              uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
-
-            - name: Set up Docker Buildx
-              uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4
-
-            - name: Pre-build with cache
-              uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7
-              with:
-                  context: .
-                  load: true
-                  tags: action-playbook:test
-                  cache-from: type=gha
-                  cache-to: type=gha,mode=max
-
-            - name: Update action.yml for testing
-              run: |
-                  sed -i 's|image: ".*"|image: "docker://action-playbook:test"|' action.yml
+            - name: Setup test image
+              uses: ./.github/actions/setup-test-image
 
             - name: Test dry_run mode (check + diff combined)
               uses: ./
@@ -593,24 +465,8 @@ jobs:
         runs-on: ubuntu-latest
         timeout-minutes: 20
         steps:
-            - name: Checkout code
-              uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
-
-            - name: Set up Docker Buildx
-              uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4
-
-            - name: Pre-build with cache
-              uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7
-              with:
-                  context: .
-                  load: true
-                  tags: action-playbook:test
-                  cache-from: type=gha
-                  cache-to: type=gha,mode=max
-
-            - name: Update action.yml for testing
-              run: |
-                  sed -i 's|image: ".*"|image: "docker://action-playbook:test"|' action.yml
+            - name: Setup test image
+              uses: ./.github/actions/setup-test-image
 
             - name: Test multiple playbooks (comma-separated)
               uses: ./
@@ -670,24 +526,8 @@ jobs:
         runs-on: ubuntu-latest
         timeout-minutes: 15
         steps:
-            - name: Checkout code
-              uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
-
-            - name: Set up Docker Buildx
-              uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4
-
-            - name: Pre-build with cache
-              uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7
-              with:
-                  context: .
-                  load: true
-                  tags: action-playbook:test
-                  cache-from: type=gha
-                  cache-to: type=gha,mode=max
-
-            - name: Update action.yml for testing
-              run: |
-                  sed -i 's|image: ".*"|image: "docker://action-playbook:test"|' action.yml
+            - name: Setup test image
+              uses: ./.github/actions/setup-test-image
 
             - name: Create vault-encrypted vars file
               run: |
@@ -713,24 +553,8 @@ jobs:
         runs-on: ubuntu-latest
         timeout-minutes: 15
         steps:
-            - name: Checkout code
-              uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
-
-            - name: Set up Docker Buildx
-              uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4
-
-            - name: Pre-build with cache
-              uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7
-              with:
-                  context: .
-                  load: true
-                  tags: action-playbook:test
-                  cache-from: type=gha
-                  cache-to: type=gha,mode=max
-
-            - name: Update action.yml for testing
-              run: |
-                  sed -i 's|image: ".*"|image: "docker://action-playbook:test"|' action.yml
+            - name: Setup test image
+              uses: ./.github/actions/setup-test-image
 
             - name: Test output_file
               uses: ./
@@ -812,24 +636,8 @@ jobs:
         runs-on: ubuntu-latest
         timeout-minutes: 15
         steps:
-            - name: Checkout code
-              uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
-
-            - name: Set up Docker Buildx
-              uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4
-
-            - name: Pre-build with cache
-              uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7
-              with:
-                  context: .
-                  load: true
-                  tags: action-playbook:test
-                  cache-from: type=gha
-                  cache-to: type=gha,mode=max
-
-            - name: Update action.yml for testing
-              run: |
-                  sed -i 's|image: ".*"|image: "docker://action-playbook:test"|' action.yml
+            - name: Setup test image
+              uses: ./.github/actions/setup-test-image
 
             - name: Test with lint enabled (expect failure - ansible-lint not in image)
               uses: ./
@@ -862,24 +670,8 @@ jobs:
         runs-on: ubuntu-latest
         timeout-minutes: 15
         steps:
-            - name: Checkout code
-              uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
-
-            - name: Set up Docker Buildx
-              uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4
-
-            - name: Pre-build with cache
-              uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7
-              with:
-                  context: .
-                  load: true
-                  tags: action-playbook:test
-                  cache-from: type=gha
-                  cache-to: type=gha,mode=max
-
-            - name: Update action.yml for testing
-              run: |
-                  sed -i 's|image: ".*"|image: "docker://action-playbook:test"|' action.yml
+            - name: Setup test image
+              uses: ./.github/actions/setup-test-image
 
             - name: Test retries with failing playbook
               uses: ./
@@ -919,24 +711,8 @@ jobs:
         runs-on: ubuntu-latest
         timeout-minutes: 15
         steps:
-            - name: Checkout code
-              uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
-
-            - name: Set up Docker Buildx
-              uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4
-
-            - name: Pre-build with cache
-              uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7
-              with:
-                  context: .
-                  load: true
-                  tags: action-playbook:test
-                  cache-from: type=gha
-                  cache-to: type=gha,mode=max
-
-            - name: Update action.yml for testing
-              run: |
-                  sed -i 's|image: ".*"|image: "docker://action-playbook:test"|' action.yml
+            - name: Setup test image
+              uses: ./.github/actions/setup-test-image
 
             - name: Test with become flags (syntax check - sudo not in container)
               uses: ./
@@ -957,24 +733,8 @@ jobs:
         runs-on: ubuntu-latest
         timeout-minutes: 20
         steps:
-            - name: Checkout code
-              uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
-
-            - name: Set up Docker Buildx
-              uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4
-
-            - name: Pre-build with cache
-              uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7
-              with:
-                  context: .
-                  load: true
-                  tags: action-playbook:test
-                  cache-from: type=gha
-                  cache-to: type=gha,mode=max
-
-            - name: Update action.yml for testing
-              run: |
-                  sed -i 's|image: ".*"|image: "docker://action-playbook:test"|' action.yml
+            - name: Setup test image
+              uses: ./.github/actions/setup-test-image
 
             - name: Test galaxy_force (reinstall)
               uses: ./
@@ -1037,24 +797,8 @@ jobs:
         runs-on: ubuntu-latest
         timeout-minutes: 15
         steps:
-            - name: Checkout code
-              uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
-
-            - name: Set up Docker Buildx
-              uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4
-
-            - name: Pre-build with cache
-              uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7
-              with:
-                  context: .
-                  load: true
-                  tags: action-playbook:test
-                  cache-from: type=gha
-                  cache-to: type=gha,mode=max
-
-            - name: Update action.yml for testing
-              run: |
-                  sed -i 's|image: ".*"|image: "docker://action-playbook:test"|' action.yml
+            - name: Setup test image
+              uses: ./.github/actions/setup-test-image
 
             - name: Test with explicit connection type
               uses: ./


### PR DESCRIPTION
## Summary

- Sixteen test jobs in `pull-request.yml` repeated the same four-step preamble (checkout, Buildx, cached pre-build, `action.yml` rewrite) verbatim. They now reference a new local composite action, `.github/actions/setup-test-image`, which cuts the workflow from 1221 to 916 lines with no change to what the jobs do.
- The `Test quality gate` step enumerated fifteen jobs by hand and never checked `test-error-handling`, even though it was a declared dependency — its failure still reported "All critical tests passed". `setup-environment` was unchecked too, and `build-action` was not a dependency at all.
- The gate now derives its verdict from `contains(needs.*.result, 'failure')` and `build-action` was added to `needs`, so every dependency is covered, including any added later.

## Test plan

- [ ] CI green on this PR: the sixteen refactored jobs must behave exactly as before, which is the equivalence check for the composite action.
- [ ] `test-summary` reports failure when any dependency fails — previously a `test-error-handling` failure passed the gate.
- [x] `yamllint -c .yamllint.yml` exits 0 for both changed files. The `too few spaces before comment` warnings on the SHA pin comments are pre-existing repo style (57 in `pull-request.yml` alone) and were left untouched.
- [x] `gitleaks` clean across the full branch diff.

Note: `actionlint` and the Go test suite could not run locally — `actionlint` is not installed and `go.mod` requires Go 1.26.5 while the sandbox has 1.22.2. Both run in CI. No Go code is touched by this branch.