### PR TITLE
refactor(lint): enable gosec and stricter govet

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -4,6 +4,43 @@ linters:
     default: standard
     enable:
         - gocritic
+        - gosec
+        # Already active under `default: standard`; listed so the intent
+        # survives a switch of `default` to `none` or `fast`.
+        - ineffassign
+        - misspell
+    settings:
+        govet:
+            enable-all: true
+            disable:
+                - fieldalignment
+                - shadow
+    exclusions:
+        rules:
+            # G204: exec.CommandContext with argument slices (ssh-add,
+            # ansible-lint). The binary name is a fixed literal, only arguments
+            # come from input, and no shell is involved. Scoped to main.go so a
+            # future `sh -c` call elsewhere is still reported.
+            - path: ^main\.go$
+              linters:
+                  - gosec
+              text: 'G204'
+            # G302, G304, G306, G703: the runner-owned files $GITHUB_OUTPUT and
+            # $GITHUB_STEP_SUMMARY plus the action's own --output-file. Their
+            # paths come from the Actions runner, and 0644 is required so the
+            # runner can read them back.
+            - path: ^main\.go$
+              linters:
+                  - gosec
+              text: '(G302|G304|G306|G703)'
+              source: '(outputFile|summaryFile)'
+            # Test fixtures generate throwaway keys and files under t.TempDir();
+            # variable paths, 0644 and the fixed ssh-keygen binary carry no risk
+            # there.
+            - path: _test\.go$
+              linters:
+                  - gosec
+              text: '(G204|G304|G306)'
 formatters:
     enable:
         - gofmt

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -22,7 +22,8 @@ This is a Docker-based GitHub Action written in Go that executes Ansible playboo
 
 - **Language**: Go 1.25+
 - **Formatting**: gofmt (built-in)
-- **Linting**: golangci-lint with staticcheck, govet, gosimple
+- **Linting**: golangci-lint (standard set) plus gocritic, gosec, ineffassign,
+  misspell and govet with `enable-all`
 - **Dependencies**: Minimal - only go.ansible, godotenv, urfave/cli
 - **Commits**: Conventional Commits format
 

--- a/main.go
+++ b/main.go
@@ -543,6 +543,8 @@ func setupKnownHosts(content string) error {
 		normalized += "\n"
 	}
 	khPath := filepath.Join(sshDir, "known_hosts")
+	// #nosec G304 -- path is built from os.UserHomeDir() and fixed literals,
+	// no part of it comes from action input. Mode stays 0600 on purpose.
 	f, err := os.OpenFile(khPath, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0600)
 	if err != nil {
 		return fmt.Errorf("failed to open known_hosts: %w", err)
@@ -689,6 +691,9 @@ func startSSHAgent(privateKey, passphrase string) (*sshAgent, error) {
 			return nil, fmt.Errorf("failed to write askpass script: %w", err)
 		}
 		_ = askpassScript.Close()
+		// #nosec G302 -- SSH_ASKPASS must be executable, so 0700 is the
+		// tightest mode that works; the file is a private temp file owned by
+		// this process and is removed once ssh-add returns.
 		if err := os.Chmod(askpassPath, 0700); err != nil {
 			_ = os.Remove(askpassPath)
 			_ = os.Remove(keyPath)
@@ -1165,6 +1170,8 @@ func writeActionOutputs(execErr error) {
 		}
 	}
 
+	// #nosec G302,G304,G703 -- path comes from $GITHUB_OUTPUT, set by the
+	// Actions runner; 0644 is required so the runner can read the file back.
 	f, err := os.OpenFile(outputFile, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0644)
 	if err != nil {
 		log.Printf("Warning: could not write action outputs: %v", err)
@@ -1205,6 +1212,8 @@ func writeStepSummary(playbooks []string, execErr error, duration time.Duration)
 	summary := fmt.Sprintf("## Ansible Playbook Results\n\n| | |\n|---|---|\n| **Playbooks** | %s |\n| **Status** | %s |\n| **Duration** | %s |\n",
 		playbookList, status, formatDuration(duration))
 
+	// #nosec G302,G304,G703 -- path comes from $GITHUB_STEP_SUMMARY, set by the
+	// Actions runner; 0644 is required so the runner can read the file back.
 	f, err := os.OpenFile(summaryFile, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0644)
 	if err != nil {
 		log.Printf("Warning: could not write step summary: %v", err)


### PR DESCRIPTION
## Summary

- Enable `gosec`, `gocritic`, `ineffassign`, `misspell` and `govet` with `enable-all` (minus `fieldalignment` and `shadow`), so the SSH agent, askpass and runner-output paths in `main.go` get the same static analysis as the library this action wraps.
- Scope the unavoidable findings with targeted `linters.exclusions.rules` plus per-site `#nosec` annotations instead of blanket `gosec.excludes`. Blanket excludes silently hid the `known_hosts` 0600 check (`main.go:546`) and the askpass chmod (`main.go:692`), and made `G703` fire on the runner-output writes.
- Update `AGENTS.md` to describe the linter set that is actually configured.

## Test plan

- [x] `golangci-lint run ./...` — 0 issues
- [x] `go test -race ./...` — pass
- [x] Regression probe: downgrading `known_hosts` from `0600` to `0666` still fails the lint run, confirming the `#nosec` annotations do not suppress real permission regressions
- [ ] CI green