### PR TITLE
docs(ci): explain the nightly security scan cadence

### DIFF
--- a/.github/workflows/nightly-security.yml
+++ b/.github/workflows/nightly-security.yml
@@ -5,7 +5,7 @@ run-name: |
 
 on:
     schedule:
-        - cron: "0 2 * * *"
+        - cron: "0 2 * * *" # Daily 02:00 UTC (public repo — Actions minutes are free)
     workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
## Summary

- Document why `nightly-security.yml` runs daily instead of the weekly baseline: the tighter cadence is deliberate and free on a public repo.
- Reuses the wording already carried by the sister repositories on the same schedule, so audits stop reporting it as drift.

## Test plan

- [ ] CI green
- [ ] actionlint, yamllint and gitleaks pass locally (pre-commit hooks)