### PR TITLE
refactor(license): add MIT header and extend copyright range

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,6 @@
-Copyright (c) 2023 Arillso
+MIT License
+
+Copyright (c) 2023-2026 Arillso
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
## Summary

- Add the missing `MIT License` first line so the notice matches the canonical layout used across the org
- Extend the copyright from the single year `2023` to the range `2023-2026`

## Test plan

- [ ] CI green (LICENSE only, no code paths touched)
- [ ] `LICENSE` starts with `MIT License`, blank line, then `Copyright (c) 2023-2026 Arillso`