### PR TITLE
refactor(renovate): pin org preset ref to 2026-08-08

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,6 +1,6 @@
 {
     "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-    "extends": ["github>arillso/.github:renovate-actions"],
+    "extends": ["github>arillso/.github:renovate-actions#2026-08-08"],
     "packageRules": [
         {
             "description": "Alpine packages (repology)",


### PR DESCRIPTION
## Summary

- Pin the org preset reference in `.github/renovate.json` from `github>arillso/.github:renovate-actions` to `github>arillso/.github:renovate-actions#2026-08-08`, matching the pinning already applied to every workflow `uses:` in this repository.
- The org-wide customManager that bumps these preset pins only matches refs that already carry a `#YYYY-MM-DD` tag, so the unpinned reference was invisible to it. Pinning enrolls this repository in that automation, and Renovate will keep the pin current from here on.
- No behaviour change: the preset blob at tag `2026-08-08` is identical to the one on the default branch.

## Test plan

- [x] `python3 -m json.tool .github/renovate.json` parses cleanly
- [x] Diff is exactly one line in one file
- [x] `go test -race ./...` passes
- [x] gitleaks clean
- [ ] CI green