### PR TITLE
fix(ci): close the gaps in the test summary quality gate

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -964,7 +964,7 @@ jobs:
                   mode: upsert
 
             - name: Test quality gate
-              if: contains(needs.*.result, 'failure')
+              if: contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled')
               run: |
-                  echo "One or more required jobs failed; see the summary above."
+                  echo "One or more required jobs failed or were cancelled; see the summary above."
                   exit 1

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -925,6 +925,9 @@ jobs:
             - name: Generate comprehensive test summary
               run: |
                   ./tests/test-summary.sh "Action-Tests" \
+                  "Go CI=${{ needs.ci.result }}" \
+                  "Lint=${{ needs.lint.result }}" \
+                  "Secret Scan=${{ needs.security-secrets.result }}" \
                   "Basic Tests=${{ needs.test-basic.result }}" \
                   "Advanced Tests=${{ needs.test-advanced.result }}" \
                   "Mode Tests=${{ needs.test-modes.result }}" \

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -892,6 +892,9 @@ jobs:
     test-summary:
         name: Test Summary
         needs:
+            - ci
+            - lint
+            - security-secrets
             - setup-environment
             - build-action
             - test-basic


### PR DESCRIPTION
## Summary

- `Test Summary` is the only required status check on `main`, but three jobs — `ci`, `lint` and `security-secrets` — were missing from its `needs` list, so they could fail without blocking a merge. They are now included.
- The quality gate only tripped on `failure`, letting a `cancelled` job pass as green. With `concurrency.cancel-in-progress: true` this is a routine outcome, not an edge case, so the gate now also trips on `cancelled`.
- The summary report gained rows for the three newly gated jobs, so the comment reflects what the gate actually checks.

`claude-review` stays out of `needs` on purpose: an AI review is not a correctness gate and is skipped on fork PRs. `skipped` remains acceptable, consistent with `tests/test-summary.sh`, which is unchanged.

## Test plan

- [ ] `yamllint` and `actionlint` pass on `.github/workflows/pull-request.yml`
- [ ] Every job except `claude-review` and `test-summary` appears in `needs` (21 entries)
- [ ] The summary reports 19 jobs, and the last argument line carries no trailing backslash
- [ ] CI green — this PR is itself the first live test of the widened gate