### PR TITLE
fix(lefthook): skip actionlint hook when the binary is missing

### DIFF
--- a/lefthook.yml
+++ b/lefthook.yml
@@ -2,7 +2,8 @@
 # Lefthook git hooks — run `lefthook install` once after cloning.
 # Tools without a system binary are installed on-demand via `npx --yes`.
 # System binaries: gofmt (from Go), golangci-lint, yamllint, gitleaks
-# (>= v8.19 for the `git --staged` subcommand), actionlint.
+# (>= v8.19 for the `git --staged` subcommand). actionlint is optional: the
+# hook skips when it is not installed.
 #
 # Stack: Go GitHub Action. Adapted from arillso/ansible.system, with
 # ansible-lint swapped for gofmt + golangci-lint. No prettier: yamllint and
@@ -28,7 +29,11 @@ pre-commit:
             run: npx --yes -- markdownlint-cli2 {staged_files}
         actionlint:
             glob: ".github/workflows/*.{yml,yaml}"
-            run: actionlint {staged_files}
+            # actionlint is often absent locally; skip instead of failing the
+            # commit with exit 127. A present-but-failing actionlint still blocks.
+            run: >-
+                command -v actionlint >/dev/null 2>&1 || { echo 'actionlint not
+                found, skipping'; exit 0; } && actionlint {staged_files}
         gitleaks:
             run: gitleaks git --staged --redact --no-banner
 


### PR DESCRIPTION
## Summary

- The `actionlint` pre-commit hook called the binary directly, so a missing `actionlint` aborted the entire commit with `sh: 1: actionlint: not found` / `exit status 127` whenever a file under `.github/workflows/` was staged.
- The hook now skips when the binary is absent, matching the guard idiom the `Makefile` already uses for `golangci-lint`, `yamllint` and `goimports`. A present-but-failing `actionlint` still blocks the commit, so lint coverage is unchanged.
- Updated the header comment, which listed `actionlint` as a required system binary.

## Test plan

- [x] `lefthook validate` passes; `lefthook dump` shows the folded `run:` collapsing to the intended single-line command.
- [x] Binary absent (`PATH` without `actionlint`): hook prints `actionlint not found, skipping` and exits 0, where the previous line exited 127.
- [x] Binary present, workflow clean: exits 0.
- [x] Binary present, workflow with real errors: exits 1, so the commit is still blocked.
- [x] `yamllint -c .yamllint.yml lefthook.yml` clean.