### PR TITLE
fix(lint): drop ineffective G306 exclusion from gosec rules

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -25,14 +25,14 @@ linters:
               linters:
                   - gosec
               text: 'G204'
-            # G302, G304, G306, G703: the runner-owned files $GITHUB_OUTPUT and
+            # G302, G304, G703: the runner-owned files $GITHUB_OUTPUT and
             # $GITHUB_STEP_SUMMARY plus the action's own --output-file. Their
             # paths come from the Actions runner, and 0644 is required so the
             # runner can read them back.
             - path: ^main\.go$
               linters:
                   - gosec
-              text: '(G302|G304|G306|G703)'
+              text: '(G302|G304|G703)'
               source: '(outputFile|summaryFile)'
             # Test fixtures generate throwaway keys and files under t.TempDir();
             # variable paths, 0644 and the fixed ssh-keygen binary carry no risk

--- a/main.go
+++ b/main.go
@@ -1170,8 +1170,9 @@ func writeActionOutputs(execErr error) {
 		}
 	}
 
-	// #nosec G302,G304,G703 -- path comes from $GITHUB_OUTPUT, set by the
-	// Actions runner; 0644 is required so the runner can read the file back.
+	// The path comes from $GITHUB_OUTPUT, set by the Actions runner; 0644 is
+	// required so the runner can read the file back. The matching gosec rules
+	// are excluded in .golangci.yml.
 	f, err := os.OpenFile(outputFile, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0644)
 	if err != nil {
 		log.Printf("Warning: could not write action outputs: %v", err)
@@ -1212,8 +1213,9 @@ func writeStepSummary(playbooks []string, execErr error, duration time.Duration)
 	summary := fmt.Sprintf("## Ansible Playbook Results\n\n| | |\n|---|---|\n| **Playbooks** | %s |\n| **Status** | %s |\n| **Duration** | %s |\n",
 		playbookList, status, formatDuration(duration))
 
-	// #nosec G302,G304,G703 -- path comes from $GITHUB_STEP_SUMMARY, set by the
-	// Actions runner; 0644 is required so the runner can read the file back.
+	// The path comes from $GITHUB_STEP_SUMMARY, set by the Actions runner; 0644
+	// is required so the runner can read the file back. The matching gosec
+	// rules are excluded in .golangci.yml.
 	f, err := os.OpenFile(summaryFile, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0644)
 	if err != nil {
 		log.Printf("Warning: could not write step summary: %v", err)


### PR DESCRIPTION
## Summary

- `G306` only applies to `os.WriteFile` and can never fire at the `os.OpenFile` call sites the exclusion was scoped to, so the entry suggested a suppression that did not exist.
- The two `#nosec G302,G304,G703` comments above the `$GITHUB_OUTPUT` and `$GITHUB_STEP_SUMMARY` writes are replaced by plain explanatory comments. `.golangci.yml` already covers those lines, and the broader `#nosec` would silently swallow a future genuine finding at exactly those lines.
- `G302`, `G304` and `G703` remain excluded; only the ineffective `G306` is dropped.

## Test plan

- [ ] `golangci-lint run ./...` reports 0 issues (CI; the linter and the Go toolchain were not reachable on the build host)
- [ ] Regression: setting the `known_hosts` mode from `0600` to `0666` still gets flagged
- [ ] CI green