### PR TITLE
fix(gitleaks): replace blanket commit allowlist with scoped placeholder regex

### DIFF
--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -9,5 +9,9 @@ useDefault = true
     '''megalinter-reports''',
     '''(.*?)gitleaks\.toml$''',
     '''(?i)(.*?)(png|jpeg|jpg|gif|doc|docx|pdf|bin|xls|xlsx|pyc|zip)$''']
-    commits = [
-    '''318d67f8b917c72ec5a58616dbf1f16fb6d29503''']
+    # Placeholder PEM blocks used as negative-path test fixtures in main_test.go:
+    # the key body is a literal marker ("not-a-real-key") or a repeated-letter stub
+    # ("AAA"/"BBB", still present in history), never real key material. Scoped to
+    # these exact bodies so genuine private keys in test files are still reported.
+    regexes = [
+    '''-----BEGIN [A-Z ]*PRIVATE KEY-----\\n(not-a-real-key|A{3}|B{3})\\n-----END [A-Z ]*PRIVATE KEY-----''']

--- a/main_test.go
+++ b/main_test.go
@@ -1099,7 +1099,7 @@ func TestSSHAgent_AddInvalidKey(t *testing.T) {
 	}
 	defer agent.stop()
 
-	if err := agent.addKey("-----BEGIN OPENSSH PRIVATE KEY-----\nnot-real\n-----END OPENSSH PRIVATE KEY-----"); err == nil {
+	if err := agent.addKey("-----BEGIN OPENSSH PRIVATE KEY-----\nnot-a-real-key\n-----END OPENSSH PRIVATE KEY-----"); err == nil {
 		t.Error("expected addKey to fail for an invalid key, got nil")
 	}
 
@@ -1270,7 +1270,7 @@ func TestRun_InvalidPrivateKey(t *testing.T) {
 	inv := createTempFile(t, tmpDir, "inv.yml", "all:\n  hosts:\n    localhost:\n")
 	err := runWithArgs(t, []string{
 		"test", "--playbook", pb, "--inventory", inv,
-		"--private-key", "-----BEGIN OPENSSH PRIVATE KEY-----\nnot-real\n-----END OPENSSH PRIVATE KEY-----",
+		"--private-key", "-----BEGIN OPENSSH PRIVATE KEY-----\nnot-a-real-key\n-----END OPENSSH PRIVATE KEY-----",
 	})
 	if err == nil {
 		t.Fatal("expected run() to fail for an invalid private key, got nil")


### PR DESCRIPTION
## Summary

- Remove the `commits` allowlist entry for `318d67f`, which suppressed **every** gitleaks finding in that revision — a real secret later discovered there would have gone unreported while CI stayed green.
- Allowlist the placeholder PEM bodies used by the negative-path SSH fixtures instead, with an inline comment stating why the exception exists. The regex is scoped to the literal placeholder bodies (`not-a-real-key`, and the `AAA`/`BBB` stubs still present in history), not to test files in general.
- Normalise the two fixture bodies in `main_test.go` to a single self-describing placeholder.

## Test plan

- [x] `gitleaks git` (full history) — no leaks found
- [x] `gitleaks dir` (working tree) — no leaks found
- [x] Counter-check: a freshly generated ed25519 private key dropped into a `_test.go` file is still reported, confirming the allowlist is not a blanket test-file exemption
- [x] `go test ./...` passes; `TestSSHAgent_AddInvalidKey` and `TestRun_InvalidPrivateKey` still fail the key as intended
- [ ] CI green