### PR TITLE
ci(security): migrate nightly scan to security-code.yml

### DIFF
--- a/.github/workflows/nightly-security.yml
+++ b/.github/workflows/nightly-security.yml
@@ -24,7 +24,11 @@ concurrency:
 
 jobs:
     codeql:
-        uses: arillso/.github/.github/workflows/security-codeql.yml@2026-08-07
+        needs: prepare
+        uses: arillso/.github/.github/workflows/security-code.yml@2026-08-07
+        with:
+            languages: '["go"]'
+            go-version: ${{ needs.prepare.outputs.go_version }}
 
     prepare:
         runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary

- Switch the nightly CodeQL job from the deprecated `security-codeql.yml` reusable workflow to its successor `security-code.yml`.
- Pass `languages` and `go-version` explicitly: the legacy workflow defaulted to `go`, while the successor defaults to `javascript-typescript`, so a bare `uses:` swap would have silently stopped scanning this Go module.
- Derive `go-version` from the existing `prepare` job's `go.mod`-based output instead of hardcoding a literal, matching how `pull-request.yml` and `tag.yml` resolve it and avoiding drift on the next Go bump.

## Test plan

- [ ] CI green
- [x] `actionlint` and `yamllint` clean on `.github/workflows/nightly-security.yml`
- [x] `go build ./...` and `go test ./...` pass locally
- [ ] Nightly run analyses Go and uploads results to the Security tab
