### PR TITLE
ci: wire security-deps and security-sbom reusables

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -38,6 +38,9 @@ jobs:
     security-secrets:
         uses: arillso/.github/.github/workflows/security-secrets.yml@2026-08-07
 
+    security-deps:
+        uses: arillso/.github/.github/workflows/security-deps.yml@2026-08-07
+
     claude-review:
         uses: arillso/.github/.github/workflows/ai-claude-review.yml@2026-08-07
         secrets:

--- a/.github/workflows/tag.yml
+++ b/.github/workflows/tag.yml
@@ -139,6 +139,13 @@ jobs:
                   subject-digest: ${{ steps.build.outputs.digest }}
                   push-to-registry: true
 
+    security-sbom:
+        needs: [prepare, build-and-push-image]
+        uses: arillso/.github/.github/workflows/security-sbom.yml@2026-08-07
+        with:
+            artifact-type: container
+            artifact-ref: ghcr.io/${{ github.repository }}:${{ needs.prepare.outputs.version }}
+
     create-release:
         runs-on: ubuntu-latest
         needs: [prepare, build-and-push-image]


### PR DESCRIPTION
## Summary

- Wire the existing `security-deps.yml` reusable into `pull-request.yml`. The repo has `go.mod`, so `go-audit` (govulncheck, license check) applies, and `dependency-review` runs because the repo is public.
- Wire `security-sbom.yml` into `tag.yml` after the image push, producing a CycloneDX SBOM artifact for the released container image.
- Both calls use the `@2026-08-07` pin, matching all eight existing reusable calls in the repo.
- `artifact-ref` is written out as `ghcr.io/${{ github.repository }}:...` rather than using `env.REGISTRY`/`env.IMAGE_NAME`. A reusable `with:` block has no `env` context, so those would silently evaluate to empty strings and only fail at runtime on the next release tag. The value is identical to the `env` block in `tag.yml`.
- No job-level `permissions:` and no changes to existing jobs. The Buildkit `sbom: true` attestation stays: different format, different consumer, no redundancy.

## Test plan

- [ ] `actionlint` clean on both workflows
- [ ] `yamllint` clean on both workflows
- [ ] `security-deps` verifies itself on this PR (both `dependency-review` and `go-audit` run)
- [ ] `security-sbom` only triggers on tag push and cannot run before the next release; the `env`-context failure mode was verified locally with actionlint
- [ ] CI green