### PR TITLE
fix(lefthook): scope pre-push go-test to Go files

### DIFF
--- a/lefthook.yml
+++ b/lefthook.yml
@@ -43,5 +43,7 @@ pre-push:
         gitleaks-full:
             run: gitleaks git --redact --no-banner
         go-test:
-            glob: "*.go"
+            # go.mod/go.sum are included: a dependency-only push can break the
+            # build or tests without touching a single *.go file.
+            glob: "{*.go,go.mod,go.sum}"
             run: go test -race ./...

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -43,4 +43,5 @@ pre-push:
         gitleaks-full:
             run: gitleaks git --redact --no-banner
         go-test:
+            glob: "*.go"
             run: go test -race ./...


### PR DESCRIPTION
## Summary

- Add `glob: "*.go"` to the `pre-push` command `go-test`; it was the only hook without one and ran the Go toolchain on every push, including diffs that touch no Go files.
- `gitleaks-full` stays unglobbed and keeps running on every push, so scoping `go-test` does not weaken the secret scan.

## Test plan

- [x] `yamllint -c .yamllint.yml lefthook.yml` passes
- [x] Pushing this YAML-only branch reports `go-test (skip) no matching push files` while `gitleaks-full` still runs
- [ ] CI green