### PR TITLE
fix(license): correct copyright start year to 2020

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2023-2026 Arillso
+Copyright (c) 2020-2026 Arillso
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
## Summary

- `LICENSE` claimed a copyright start year of 2023, three years later than the actual first commit (2020-04-06), understating the protected period in the legally relevant file of a public repository.
- Corrected the start year to 2020 so `LICENSE`, `README.md` and the git history all agree. End year 2026 unchanged.

## Test plan

- [ ] `sed -n '3p' LICENSE` reads `Copyright (c) 2020-2026 Arillso`
- [ ] Matches `README.md:406` (`(c) 2020-2026, Arillso`) and `git log --reverse` first commit date `2020-04-06`
- [ ] `go test -race ./...` green, gitleaks clean, CI green