### PR TITLE
refactor(lint): align yamllint config with org norm

### DIFF
--- a/.yamllint.yml
+++ b/.yamllint.yml
@@ -1,21 +1,66 @@
 ---
 extends: default
+
 rules:
     line-length:
         max: 500
+        level: warning
+
+    comments:
+        min-spaces-from-content: 1
+
+    comments-indentation: false
+
     indentation:
         spaces: 4
         indent-sequences: true
+        check-multi-line-strings: false
+
     truthy:
-        allowed-values: ['true', 'false']
+        allowed-values: ["true", "false"]
         check-keys: false
-    comments:
-        min-spaces-from-content: 1
+
+    brackets:
+        min-spaces-inside: 0
+        max-spaces-inside: 0
+
+    braces:
+        min-spaces-inside: 0
+        max-spaces-inside: 1
+
+    colons:
+        max-spaces-before: 0
+        max-spaces-after: 1
+
+    commas:
+        max-spaces-before: 0
+        max-spaces-after: 1
+
+    hyphens:
+        max-spaces-after: 1
+
+    empty-lines:
+        max: 2
+        max-start: 0
+        max-end: 1
+
     document-start:
         present: true
+
+    document-end:
+        present: false
+
+    trailing-spaces: {}
+
+    key-duplicates: {}
+
+    new-lines:
+        type: unix
+
     octal-values:
         forbid-implicit-octal: true
         forbid-explicit-octal: true
+
 ignore: |
     .ansible/
     .venv/


### PR DESCRIPTION
## Summary

- Adds the eleven yamllint rule blocks the Ansible collections enforce but this repo did not (`comments-indentation`, `brackets`, `braces`, `colons`, `commas`, `hyphens`, `empty-lines`, `document-end`, `trailing-spaces`, `key-duplicates`, `new-lines`), taking the config from 6 to 17 rule blocks.
- Adds `line-length.level: warning` and `indentation.check-multi-line-strings: false` to match the norm; `line-length.max: 500` and `truthy.check-keys: false` were already in place.
- Keeps the repo-specific `ignore:` block unchanged — it lists `tests/`, which the norm does not, and adopting the norm's list verbatim would fail the lint run on 12 files.

## Test plan

- [x] `yamllint -s -c .yamllint.yml .` exits 0
- [x] `yamllint -s -c .yamllint.yml .yamllint.yml` (config checked against itself) exits 0
- [x] `make lint-yaml` exits 0 and actually invokes the linter
- [x] All tracked YAML linted file-by-file (the pre-commit hook path, which bypasses `ignore:`) exits 0
- [x] Negative controls: `key-duplicates` and `trailing-spaces` each exit 1 against a deliberately broken file
- [ ] CI green