### PR TITLE
fix(lefthook): fail instead of skip when actionlint is missing

### DIFF
--- a/lefthook.yml
+++ b/lefthook.yml
@@ -1,9 +1,10 @@
 ---
 # Lefthook git hooks — run `lefthook install` once after cloning.
 # Tools without a system binary are installed on-demand via `npx --yes`.
-# System binaries: gofmt (from Go), golangci-lint, yamllint, gitleaks
-# (>= v8.19 for the `git --staged` subcommand). actionlint is optional: the
-# hook skips when it is not installed.
+# System binaries: gofmt (from Go), golangci-lint, yamllint, actionlint,
+# gitleaks (>= v8.19 for the `git --staged` subcommand). All of them are
+# required: a missing linter blocks the commit instead of skipping, so the
+# hooks cannot be bypassed by uninstalling the tool.
 #
 # Stack: Go GitHub Action. Adapted from arillso/ansible.system, with
 # ansible-lint swapped for gofmt + golangci-lint. No prettier: yamllint and
@@ -29,11 +30,13 @@ pre-commit:
             run: npx --yes -- markdownlint-cli2 {staged_files}
         actionlint:
             glob: ".github/workflows/*.{yml,yaml}"
-            # actionlint is often absent locally; skip instead of failing the
-            # commit with exit 127. A present-but-failing actionlint still blocks.
+            # The guard only turns the bare exit 127 into a readable message;
+            # it must not skip, or deleting the binary would bypass the hook.
             run: >-
                 command -v actionlint >/dev/null 2>&1 || { echo 'actionlint not
-                found, skipping'; exit 0; } && actionlint {staged_files}
+                found: install it (brew install actionlint) or see
+                https://github.com/rhysd/actionlint'; exit 1; } && actionlint
+                {staged_files}
         gitleaks:
             run: gitleaks git --staged --redact --no-banner
 

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -11,6 +11,11 @@
 # markdownlint already cover yml/md, and the repo's 4-space YAML/.editorconfig
 # conventions diverge from Prettier's defaults.
 
+# Every hook below guards its binary the same way: the guard turns the bare
+# exit 127 into a message naming the tool and how to install it, then exits 1.
+# It must never skip — deleting the binary would otherwise bypass the hook.
+# markdownlint needs no guard: npx fetches it on demand.
+
 pre-commit:
     parallel: true
     commands:
@@ -18,27 +23,41 @@ pre-commit:
             glob: "*.go"
             # gofmt -l only prints unformatted files and still exits 0, so the
             # commit must be blocked explicitly when the list is non-empty.
-            run: test -z "$(gofmt -l {staged_files})"
+            # The guard runs first: inside $(...) a missing gofmt would yield
+            # an empty list, which `test -z` would read as "all formatted".
+            run: >-
+                command -v gofmt >/dev/null 2>&1 || { echo 'gofmt not found:
+                install Go (https://go.dev/dl/)'; exit 1; } && test -z
+                "$(gofmt -l {staged_files})"
         golangci-lint:
             glob: "*.go"
-            run: golangci-lint run
+            run: >-
+                command -v golangci-lint >/dev/null 2>&1 || { echo
+                'golangci-lint not found: see
+                https://golangci-lint.run/welcome/install/'; exit 1; } &&
+                golangci-lint run
         yamllint:
             glob: "*.{yml,yaml}"
-            run: yamllint -c .yamllint.yml {staged_files}
+            run: >-
+                command -v yamllint >/dev/null 2>&1 || { echo 'yamllint not
+                found: pip install yamllint'; exit 1; } && yamllint -c
+                .yamllint.yml {staged_files}
         markdownlint:
             glob: "*.md"
             run: npx --yes -- markdownlint-cli2 {staged_files}
         actionlint:
             glob: ".github/workflows/*.{yml,yaml}"
-            # The guard only turns the bare exit 127 into a readable message;
-            # it must not skip, or deleting the binary would bypass the hook.
             run: >-
                 command -v actionlint >/dev/null 2>&1 || { echo 'actionlint not
                 found: install it (brew install actionlint) or see
                 https://github.com/rhysd/actionlint'; exit 1; } && actionlint
                 {staged_files}
         gitleaks:
-            run: gitleaks git --staged --redact --no-banner
+            run: >-
+                command -v gitleaks >/dev/null 2>&1 || { echo 'gitleaks not
+                found (>= v8.19 required): see
+                https://github.com/gitleaks/gitleaks#installing'; exit 1; } &&
+                gitleaks git --staged --redact --no-banner
 
 pre-push:
     parallel: true


### PR DESCRIPTION
## Summary

- The `actionlint` pre-commit hook skipped silently when the binary was missing, so uninstalling it was enough to bypass linting entirely — the hook could no longer guarantee what it exists to guarantee. It now exits `1`.
- `gofmt` was worse than unhelpful: with the binary absent, `test -z "$(gofmt -l …)"` saw an empty list and passed, waving unformatted Go through.
- Every remaining hook (`golangci-lint`, `yamllint`, `gitleaks`) failed with a bare `exit 127` naming neither the tool nor how to install it. Each now checks its binary first and exits `1` with an install hint.
- `markdownlint` needs no guard — `npx --yes` fetches it on demand.
- The header comment listed `actionlint` as optional; it now documents all linters as required.

## Test plan

- [x] `yamllint -c .yamllint.yml lefthook.yml` passes
- [x] Each guard with its binary absent: prints the install hint, exits `1`
- [x] `gofmt` guard specifically: the old form returned `0` with the binary absent, the new one returns `1`
- [x] Guards with binaries present: hooks run and pass (verified by the commits on this branch)
- [ ] CI green
