### PR TITLE
fix(lint): drop non-existent G703 from gosec exclusion

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -25,14 +25,14 @@ linters:
               linters:
                   - gosec
               text: 'G204'
-            # G302, G304, G703: the runner-owned files $GITHUB_OUTPUT and
+            # G302, G304: the runner-owned files $GITHUB_OUTPUT and
             # $GITHUB_STEP_SUMMARY plus the action's own --output-file. Their
             # paths come from the Actions runner, and 0644 is required so the
             # runner can read them back.
             - path: ^main\.go$
               linters:
                   - gosec
-              text: '(G302|G304|G703)'
+              text: '(G302|G304)'
               source: '(outputFile|summaryFile)'
             # Test fixtures generate throwaway keys and files under t.TempDir();
             # variable paths, 0644 and the fixed ssh-keygen binary carry no risk


### PR DESCRIPTION
## Summary

- `gosec` defines no `G7xx` rule (upstream `rules/rulelist.go` covers G101–G117, G201–G204, G301–G307, G401–G406, G501–G507, G601), so the `G703` alternative in the exclusion regex never matched.
- Removes `G703` from the `text` regex and the explanatory comment in `.golangci.yml`, same defect class as the `G306` removal in #214.
- No behaviour change: `G302` and `G304` stay excluded, `source: '(outputFile|summaryFile)'` is untouched.

## Test plan

- [ ] `Go Lint` reports 0 issues, unchanged against `main` — this is the only empirical check, no Go toolchain or `golangci-lint` available locally
- [x] `yamllint -c .yamllint.yml .golangci.yml` clean
- [x] `rg -n 'G703' .` returns no hits repo-wide