### PR TITLE
fix(lint): disable MD041 for CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,1 +1,3 @@
+<!-- markdownlint-disable-file MD041 -->
+
 @AGENTS.md


### PR DESCRIPTION
## Summary

- `CLAUDE.md` is a single-line import of `AGENTS.md` with no H1 by design, so the `markdownlint` pre-commit hook failed it with `MD041/first-line-heading` and blocked every commit that staged the file.
- The only workaround was `--no-verify`, which also disables `gitleaks`, `yamllint`, `ansible-lint` and `actionlint` — so a formatting rule was silently turning off the secret scanner.
- Adds a file-scoped `<!-- markdownlint-disable-file MD041 -->` header instead of touching `.markdownlint.json`, leaving the org-wide config untouched. Matches the existing pattern in `arillso/ansible.agent`.

## Test plan

- [x] Reproduced before the fix: `markdownlint-cli2 CLAUDE.md` reported `CLAUDE.md:1 error MD041/first-line-heading/first-line-h1`
- [x] After the fix: `markdownlint-cli2 CLAUDE.md` reports `0 issues`
- [x] Full pre-commit hook passes on the staged file (`markdownlint`, `gitleaks`)
- [x] All tracked `*.md` files linted; no other `MD041` violations
- [ ] CI green