### PR TITLE
docs(readme): add blank line before SSH key normalization list

### DIFF
--- a/README.md
+++ b/README.md
@@ -328,6 +328,7 @@ them as action inputs via `with:` or as environment variables via `env:`.
 > **✨ New in v1.2.0+**
 >
 > SSH private keys are automatically normalized:
+>
 > - Windows line endings (CRLF) → Unix format (LF)
 > - Missing trailing newlines are added
 > - Format validation (RSA, OpenSSH, EC, DSA)


### PR DESCRIPTION
## Summary

- The list inside the `## SSH Authentication` blockquote had no blank line before it, so `markdownlint-cli2` flagged `MD032/blanks-around-lists`.
- The `markdownlint` step in the lefthook `pre-commit` hook globs `*.md`, so this blocked every commit that staged `README.md` unless bypassed with `--no-verify` (which also disables gitleaks, yamllint, ansible-lint and actionlint).
- Fixed by adding a `>` blank line inside the blockquote. `.markdownlint.json` is untouched.

## Test plan

- [x] `npx --yes -- markdownlint-cli2 "**/*.md"` reports no `MD032` (0 issues on `README.md`)
- [x] lefthook `pre-commit` passes on a commit staging `README.md`
- [ ] CI green