### PR TITLE
fix(security): update Go to 1.26.6 for stdlib vulnerabilities

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 # -------------------------
 # Stage 1: Build Stage
 # -------------------------
-FROM --platform=$BUILDPLATFORM golang:1.26-alpine@sha256:0178a641fbb4858c5f1b48e34bdaabe0350a330a1b1149aabd498d0699ff5fb2 AS builder
+FROM --platform=$BUILDPLATFORM golang:1.26-alpine@sha256:3889b425f035be855a72fb4755265311293b6d414521f0a519d819df32222d83 AS builder
 # Use the official Golang Alpine image and assign this build stage the name "builder".
 # The builder runs natively on the build platform and cross-compiles for the target.
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/arillso/action.playbook
 
-go 1.26.5
+go 1.26.6
 
 require (
 	github.com/arillso/go.ansible/v2 v2.0.0


### PR DESCRIPTION
## Summary

- Bumps the `go` directive to 1.26.6. Go 1.26.5 stdlib is affected by eight known vulnerabilities (GO-2026-5026, -5942, -5972, -6088, -6089, -6090, -6091, -6218) that fail the `Audit Go` job on `main` and on every open branch.
- Bumps the builder image digest in the same commit. The pinned digest still resolved to Go 1.26.5, so bumping `go.mod` alone breaks `go mod download` under `GOTOOLCHAIN=local` — that is exactly how #230 fails today.

Nightly security has been red since 2026-08-12; this is the cause, not the open Renovate PRs. With this merged, #230 becomes redundant and should close.

## Test plan

- [x] `go build ./...` passes locally on 1.26.6
- [x] `govulncheck ./...` reports `No vulnerabilities found` (was 8 findings)
- [x] `docker build --target builder` succeeds — the `go mod download` step that fails in #230
- [ ] CI green