### PR TITLE
ci(security): adopt security-code and security-sbom from 2026-08-16

### DIFF
--- a/.github/workflows/nightly-security.yml
+++ b/.github/workflows/nightly-security.yml
@@ -25,7 +25,7 @@ concurrency:
 jobs:
     codeql:
         needs: prepare
-        uses: arillso/.github/.github/workflows/security-code.yml@2026-08-15
+        uses: arillso/.github/.github/workflows/security-code.yml@2026-08-16
         with:
             languages: '["go"]'
             go-version: ${{ needs.prepare.outputs.go_version }}

--- a/.github/workflows/tag.yml
+++ b/.github/workflows/tag.yml
@@ -141,7 +141,7 @@ jobs:
 
     security-sbom:
         needs: [prepare, build-and-push-image]
-        uses: arillso/.github/.github/workflows/security-sbom.yml@2026-08-15
+        uses: arillso/.github/.github/workflows/security-sbom.yml@2026-08-16
         with:
             artifact-type: container
             artifact-ref: ghcr.io/${{ github.repository }}:${{ needs.prepare.outputs.version }}


### PR DESCRIPTION
## Summary

Picks up the concurrency fix from `arillso/.github#111`.

`security-code.yml` and `security-sbom.yml` had a `concurrency` group of bare `${{ github.workflow }}-${{ github.ref }}`. Inside a `workflow_call` reusable those resolve to the *caller*, so the group was byte-identical to the one the calling workflow declares for itself, and with `cancel-in-progress` defaulting to `true` the job was dropped at scheduling time.

That is why the nightly scan has reported `failure` while every job it created is green, with no annotation and no log — the CodeQL job never existed. Run 31978965228 on `main` shows the symptom: `prepare`, `build-test-image` and `security-test` all succeed, and the codeql job is absent from the jobs list entirely.

Only the two affected pins move here; Renovate owns the rest.

## Test plan

- [x] Verified in `go.ansible` (run 31979293143) that the same tag bump makes `codeql / Analyze Code (go)` appear and execute, where on `main` it is never created
- [ ] Nightly scan on this branch creates the CodeQL job and concludes success